### PR TITLE
Fix facet price filter label spacing (#300)

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -641,7 +641,7 @@ summary .icon-caret {
   position: absolute;
   height: 0.6rem;
   right: 1.5rem;
-  top: calc(50% - 0.35rem);
+  top: calc(50% - 0.2rem);
 }
 
 summary::-webkit-details-marker {
@@ -1287,7 +1287,7 @@ deferred-media {
   height: 0.6rem;
   pointer-events: none;
   position: absolute;
-  top: calc(50% - 0.35rem);
+  top: calc(50% - 0.2rem);
   right: 1.5rem;
 }
 

--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -348,7 +348,7 @@ noscript .localization-form__select {
   content: '';
   height: 0.6rem;
   right: 1.5rem;
-  top: calc(50% - 0.35rem);
+  top: calc(50% - 0.2rem);
 }
 
 .localization-selector.link {

--- a/assets/template-collection.css
+++ b/assets/template-collection.css
@@ -280,7 +280,7 @@
   padding: 2rem;
 }
 
-.facets__price > * + * {
+.facets__price .field + .field-currency {
   margin-left: 2rem;
 }
 
@@ -288,12 +288,13 @@
   align-items: center;
 }
 
-.facets__price .field .field__currency {
+.facets__price .field-currency {
+  align-self: center;
   margin-right: 0.6rem;
 }
 
 .facets__price .field__label {
-  left: 2.1rem;
+  left: 1.5rem;
 }
 
 button.facets__button {

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1146,6 +1146,14 @@
             }
           }
         },
+        "custom_liquid": {
+          "name": "Custom liquid",
+          "settings": {
+            "custom_liquid": {
+              "label": "Custom liquid"
+            }
+          }
+        },
         "collapsible_tab": {
           "name": "Collapsible tab",
           "settings": {

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -103,7 +103,7 @@
                   </summary>
                   <div class="facets__display">
                     <div class="facets__header">
-                      {%- assign max_price_amount = filter.range_max | money | escape -%}
+                      {%- assign max_price_amount = filter.range_max | money | strip_html | escape -%}
                       <span class="facets__selected">{{ "sections.collection_template.max_price" | t: price: max_price_amount }}</span>
                       <facet-remove>
                         <a href="{{ filter.url_to_remove }}" class="facets__reset link underlined-link" >
@@ -112,8 +112,8 @@
                       </facet-remove>
                     </div>
                     <price-range class="facets__price">
+                      <span class="field-currency">{{ cart.currency.symbol }}</span>
                       <div class="field">
-                        <span class="field__currency">{{ cart.currency.symbol }}</span>
                         <input class="field__input"
                           name="{{ filter.min_value.param_name }}"
                           id="Filter-{{ filter.label | escape }}-GTE"
@@ -128,8 +128,9 @@
                         </input>
                         <label class="field__label" for="Filter-{{ filter.label | escape }}-GTE">{{ 'sections.collection_template.from' | t }}</label>
                       </div>
+
+                      <span class="field-currency">{{ cart.currency.symbol }}</span>
                       <div class="field">
-                        <span class="field__currency">{{ cart.currency.symbol }}</span>
                         <input class="field__input"
                           name="{{ filter.max_value.param_name }}"
                           id="Filter-{{ filter.label | escape }}-LTE"
@@ -311,8 +312,8 @@
                         <p class="mobile-facets__info">{{ "sections.collection_template.max_price" | t: price: max_price_amount }}</p>
 
                         <price-range class="facets__price">
+                          <span class="field-currency">{{ cart.currency.symbol }}</span>
                           <div class="field">
-                            <span class="field__currency">{{ cart.currency.symbol }}</span>
                             <input class="field__input"
                               name="{{ filter.min_value.param_name }}"
                               id="Mobile-Filter-{{ filter.label | escape }}-GTE"
@@ -327,8 +328,9 @@
                             </input>
                             <label class="field__label" for="Mobile-Filter-{{ filter.label | escape }}-GTE">{{ 'sections.collection_template.from' | t }}</label>
                           </div>
+
+                          <span class="field-currency">{{ cart.currency.symbol }}</span>
                           <div class="field">
-                            <span class="field__currency">{{ cart.currency.symbol }}</span>
                             <input class="field__input"
                               name="{{ filter.max_value.param_name }}"
                               id="Mobile-Filter-{{ filter.label | escape }}-LTE"

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -98,6 +98,8 @@
                 {{ product.description }}
               </div>
             {%- endif -%}
+          {%- when 'custom_liquid' -%}
+            {{ block.settings.custom_liquid }}
           {%- when 'collapsible_tab' -%}
             <div class="product__accordion accordion" {{ block.shopify_attributes }}>
               <details>
@@ -565,6 +567,17 @@
         {
           "type": "paragraph",
           "content": "t:sections.main-product.blocks.share.settings.title_info.content"
+        }
+      ]
+    },
+    {
+      "type": "custom_liquid",
+      "name": "t:sections.main-product.blocks.custom_liquid.name",
+      "settings": [
+        {
+          "type": "liquid",
+          "id": "custom_liquid",
+          "label": "t:sections.main-product.blocks.custom_liquid.settings.custom_liquid.label"
         }
       ]
     },


### PR DESCRIPTION
* Fix facet price filter label spacing

* Move currency label out of the wrapperto fix the absolute position

* add strip_html to the message when filtering price

* apply strip_html before | escape filter

**Why are these changes introduced?**

Fixes #0.

**What approach did you take?**

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
